### PR TITLE
Revert "Table is Array and Table::Row is Hash"

### DIFF
--- a/lib/bamfcsv/table.rb
+++ b/lib/bamfcsv/table.rb
@@ -30,16 +30,6 @@ module BAMFCSV
       "[#{self.map{|r| r.inspect}.join(", ")}]"
     end
 
-    alias __is_a? is_a?
-    def is_a?(other)
-      Array == other || __is_a?(other)
-    end
-
-    alias __kind_of? kind_of?
-    def kind_of?(other)
-      Array == other || __kind_of?(other)
-    end
-
     private
     def row_hash(row)
       Hash[@headers.zip(row)]
@@ -59,16 +49,6 @@ module BAMFCSV
 
       def [](key)
         @fields[@header_map[key]]
-      end
-
-      alias __is_a? is_a?
-      def is_a?(other)
-        Hash == other || __is_a?(other)
-      end
-
-      alias __kind_of? kind_of?
-      def kind_of?(other)
-        Hash == other || __kind_of?(other)
       end
 
       def inspect

--- a/spec/lib/bamfcsv_spec.rb
+++ b/spec/lib/bamfcsv_spec.rb
@@ -138,28 +138,6 @@ describe BAMFCSV do
   end
 
   describe "generating a Table" do
-    describe "identity" do
-      let(:table) { BAMFCSV.parse("foo,bar\n1,2", :headers => true) }
-      it "Table isa Array" do
-        table.kind_of?(Array).should be_true
-        table.is_a?(Array).should be_true
-      end
-      
-      it "Array === table" do
-        pending { (Array === table).should be_true }
-      end
-
-      it "Table::Row isa Hash" do
-        row = table.first
-        row.kind_of?(Hash).should be_true
-        row.is_a?(Hash).should be_true
-      end
-
-      it "Hash === row" do
-        pending { (Hash === row).should be_true }
-      end
-    end
-
     describe "with only a header" do
       let(:header_only) { BAMFCSV.parse("1,2,3", :headers => true) }
       it "has no body rows" do


### PR DESCRIPTION
This reverts commit 3d8c1ce5d31633dfa065db0be2d401bd34ac6fbb.

Reverted recent change making Table look like an Array and Row look like a hash.  Table does not implement all methods of Array; specifically it doesn't implement #replace, which causes issues within ActiveSupport::HashWithIndifferentAccess#convert_value (https://github.com/rails/rails/blob/master/activesupport/lib/active_support/hash_with_indifferent_access.rb#L150).
