### PR TITLE
Add BAMFCSV::Table#empty?

### DIFF
--- a/lib/bamfcsv/table.rb
+++ b/lib/bamfcsv/table.rb
@@ -26,6 +26,10 @@ module BAMFCSV
       @row_cache[idx] ||= Row.new(@header_map, @matrix[idx])
     end
 
+    def empty?
+      @matrix.empty?
+    end
+
     def inspect
       "[#{self.map{|r| r.inspect}.join(", ")}]"
     end

--- a/spec/lib/bamfcsv_spec.rb
+++ b/spec/lib/bamfcsv_spec.rb
@@ -216,6 +216,28 @@ CSV
       end
     end
 
+    describe "Table#empty?" do
+      it "returns true for an empty table with headers" do
+        table = BAMFCSV.parse("column1,column2\n", :headers => true)
+        table.empty?.should be_true
+      end
+
+      it "returns false for a non-empty table with headers" do
+        table = BAMFCSV.parse("column1,column2\nfoo,bar", :headers => true)
+        table.empty?.should be_false
+      end
+
+      it "returns true for an empty table without headers" do
+        table = BAMFCSV.parse("", :headers => false)
+        table.empty?.should be_true
+      end
+
+      it "returns false for a non-empty table without headers" do
+        table = BAMFCSV.parse("foo,bar", :headers => false)
+        table.empty?.should be_false
+      end
+    end
+
     describe "Table::Row#inspect" do
       it "is a Hash" do
         csv = <<CSV


### PR DESCRIPTION
Add BAMFCSV::Table#empty? by delegating it to @matrix.  This is a useful helper method, and is provided by the standard CSV::Table class.
