### PR TITLE
Copy input string before calling __parse_string

### DIFF
--- a/lib/bamfcsv.rb
+++ b/lib/bamfcsv.rb
@@ -9,7 +9,12 @@ module BAMFCSV
 
   def self.parse(csv_str, opts={})
     return [] if csv_str.empty?
-    matrix = __parse_string(csv_str)
+    # We need to do this because the C extension currently overwrites
+    # the input, and all of String#clone, String#dup, and String.new
+    # copy the pointer, not the contents. So we make a copy, parse
+    # that, and throw away the copy.
+    copy = "" + csv_str
+    matrix = __parse_string(copy)
     if opts[:headers]
       Table.new(matrix)
     else

--- a/spec/lib/bamfcsv_spec.rb
+++ b/spec/lib/bamfcsv_spec.rb
@@ -74,6 +74,15 @@ describe BAMFCSV do
       BAMFCSV.parse("1\r\n2").should == [["1"],["2"]]
     end
 
+    it "doesn't alter the input" do
+      original = %Q{this,that,"the ""other"" thing"\r\n1,2,3\n}
+      # String#dup, String#clone, and String.new copy the pointer but
+      # share the same underlying buffer, d'oh!
+      input = "" + original
+      BAMFCSV.parse(input)
+      input.should == original
+    end
+
     describe "default CSV module compatibility" do
       it "adds a nil cell after a trailing comma with no newline" do
         BAMFCSV.parse("1,2,").should == [["1","2",nil]]


### PR DESCRIPTION
__parse_string() modifies the input string, so it's essential to make a duplicate of the input string before passing it to this function.
